### PR TITLE
Change from boxes to accordion layout, improvements to map selection

### DIFF
--- a/server.R
+++ b/server.R
@@ -195,7 +195,7 @@ function(input, output, session){
     tagList(
       fluidRow(
         column(width=4,
-               wellPanel(style = WellPanelStyle, tags$b("Step1:",  "Filter your data"), tags$hr(),
+               wellPanel(style = WellPanelStyle, tags$b("Step1:",  "Filter data"), tags$hr(),
                          lapply(FilterAttributes[FilterAttributes %in% names(data.start)], function(attrib) {
                                   choices <- GetNamedChoices(attrib, data.start)
                                   if (attrib %in% FilterSingleChoiceAttributes) { 
@@ -719,11 +719,11 @@ function(input, output, session){
     toBeHighlighted <- !(CUs %in% map.highlightedMarkers())
     if (any(toBeHighlighted)) {
       df <- withSpatialSelection(isolate(data.spatial()))
-      if (!is.null(df)) {
+      df <- df[df$Base.Unit.CU.ShortName %in% CUs[toBeHighlighted], , drop=F]
+      if (!is.null(df) && nrow(df) > 0) {
         for (CU in CUs[toBeHighlighted]) {
           CUmapProxy %>% removeMarker(CU)
         }
-        df <- df[df$Base.Unit.CU.ShortName %in% CUs[toBeHighlighted], ]
         CUmapProxy %>% addMarkers(data=df, lng=~longitude, lat=~latitude, 
                                   layerId = ~Base.Unit.CU.ShortName, 
                                   icon = ~fishIcons[icon],
@@ -738,11 +738,11 @@ function(input, output, session){
     toBeUnhighlighted <- CUs %in% map.highlightedMarkers()
     if (any(toBeUnhighlighted)) {
       df <- withSpatialSelection(data.spatial())
-      if (!is.null(df)) {
+      df <- df[df$Base.Unit.CU.ShortName %in% CUs[toBeUnhighlighted], , drop=F]
+      if (!is.null(df) && nrow(df) > 0) {
         for (CU in CUs[toBeUnhighlighted]) {
           CUmapProxy %>% removeMarker(CU)
         }
-        df <- df[df$Base.Unit.CU.ShortName %in% CUs[toBeUnhighlighted], ]
         CUmapProxy %>% addMarkers(data=df, lng=~longitude, lat=~latitude, 
                                   layerId = ~Base.Unit.CU.ShortName, 
                                   icon = ~fishIcons[icon],

--- a/ui.R
+++ b/ui.R
@@ -13,6 +13,7 @@
 # ====================== Define UI Components =========================
 
 library(shinydashboard)
+library(shinydashboardPlus)
 library(shinyWidgets)
 library(markdown)
 library(shinyBS)
@@ -93,26 +94,36 @@ tags$head(tags$style(
       
     tabItem(
       tabName = "CUSelection",
-      box(title = "Start here", width=12, solidHeader=TRUE, collapsible=TRUE, collapsed=FALSE, status=BoxHeaderStatus,
-          uiOutput("box_DataFilters")),
-      
-      box(title = "Select CUs by attributes and/or metric values", width=12, solidHeader=TRUE, collapsible=TRUE, collapsed=TRUE, status=BoxHeaderStatus,
-          uiOutput("box_DataSelectors")),
-      
-      box(title = "View/select CUs on a map", width=12, solidHeader=TRUE, collapsible=TRUE, collapsed=TRUE, status=BoxHeaderStatus,
-          uiOutput("box_LeafletMap")),
-      
-      box(title = "View/select CUs by performance metric (parallel coordinates plot)", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
-          uiOutput("box_Parcoords")),
+      accordion(
+        accordionItem(uiOutput("box_DataFilters"), id = 1, title = "Start here", collapsed=FALSE, color="Primary"),
+        accordionItem(uiOutput("box_DataSelectors"), id = 2, title = "Select CUs by attributes and/or metric values", color="Primary"),
+        accordionItem(uiOutput("box_LeafletMap"), id = 3, title = "View/select CUs on a map", color="Primary"),
+        accordionItem(uiOutput("box_Parcoords"), id = 4, title = "View/select CUs by performance metric (parallel coordinates plot)", color="Primary"),
+        accordionItem(div(style = 'overflow-x: scroll', uiOutput("box_SelectedDataTable")), id = 5, title = "View/select CUs on a data table", color="Primary"),
+        accordionItem(uiOutput("box_HistoSummary"), id = 6, title = "Summary report", color="Primary"),
+        accordionItem(uiOutput("box_RadarPlots"), id = 7, title = "Radar plots", color="Primary")
+      )
 
-      box(title = "View/select CUs on a data table", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
-          div(style = 'overflow-x: scroll', uiOutput("box_SelectedDataTable"))),
-      
-      box(title = "Summary report", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
-          uiOutput("box_HistoSummary")),
-      
-      box(title = "Radar plots", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
-          uiOutput("box_RadarPlots"))
+      # box(title = "Start here", width=12, solidHeader=TRUE, collapsible=TRUE, collapsed=FALSE, status=BoxHeaderStatus,
+      #     uiOutput("box_DataFilters")),
+      # 
+      # box(title = "Select CUs by attributes and/or metric values", width=12, solidHeader=TRUE, collapsible=TRUE, collapsed=TRUE, status=BoxHeaderStatus,
+      #     uiOutput("box_DataSelectors")),
+      # 
+      # box(title = "View/select CUs on a map", width=12, solidHeader=TRUE, collapsible=TRUE, collapsed=TRUE, status=BoxHeaderStatus,
+      #     uiOutput("box_LeafletMap")),
+      # 
+      # box(title = "View/select CUs by performance metric (parallel coordinates plot)", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
+      #     uiOutput("box_Parcoords")),
+      # 
+      # box(title = "View/select CUs on a data table", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
+      #     div(style = 'overflow-x: scroll', uiOutput("box_SelectedDataTable"))),
+      # 
+      # box(title = "Summary report", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
+      #     uiOutput("box_HistoSummary")),
+      # 
+      # box(title = "Radar plots", width=12, solidHeader=TRUE, collapsible=TRUE,  collapsed=TRUE, status=BoxHeaderStatus,
+      #     uiOutput("box_RadarPlots"))
     )
   )
 )

--- a/ui.R
+++ b/ui.R
@@ -47,10 +47,10 @@ body <- shinydashboard::dashboardBody(`style` = "min-height: 400px",
   shinyjs::useShinyjs(),
   tags$head(HTML("<script type='text/javascript' src='sbs/shinyBS.js'></script>")),
 
-tags$head(tags$style(
-  HTML('.skin-blue {min-height: 400px !important;}')
-)),
-tags$head(tags$style(HTML('
+  tags$head(tags$style(
+    HTML('.skin-blue {min-height: 400px !important;}')
+  )),
+  tags$head(tags$style(HTML('
         .skin-blue .main-header .logo {
                             background-color: #3c8dbc;
                             }
@@ -130,7 +130,12 @@ tags$head(tags$style(
 
 # Define UI for application 
 ui <- dashboardPage(
-  dashboardHeader(title="Working"),
+  dashboardHeader(
+# sample code for adding buttons and other elements to header bar    
+#    tags$li(class = "dropdown", actionButton("btn1", label = "Button 1", style=ButtonStyle)),
+#    tags$li(class = "dropdown", conditionalPanel("input.tabs == 'CUSelection'",
+#                                                  actionButton("btn3", label = "Clear Selection", style=ButtonStyle))),
+                  title="Working"),
   #  dashboardSidebar(disable=F),
   sidebar,
   body


### PR DESCRIPTION
Accordion layout automatically closes a box once the user opens another one. Having only one box open prevents/mitigates issue with shiny getting into an infinite loop when the user selects items more quickly than the browser can refresh the state of the open boxes.
Now allowing for toggling selection when  user selects CUs via a stream segment. Also added reactive value to keep track of which markers are highlighted, so redrawing of map components is kept to a minimum.